### PR TITLE
chore: publish charm to Charmhub

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,3 +35,13 @@ jobs:
     needs: 
       - build
     uses: ./.github/workflows/integration-test.yaml
+
+  publish-charm:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+      - integration-test
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
+    uses: ./.github/workflows/publish-charm.yaml
+    secrets: inherit

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -1,0 +1,41 @@
+name: Publish charm
+
+on:
+  workflow_call:
+    secrets:
+      CHARMCRAFT_AUTH:
+        required: true
+
+jobs:
+  publish-charm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Fetch Tested Charm
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
+      - name: Upload charm to Charmhub
+        uses: canonical/charming-actions/upload-charm@2.6.2
+        with:
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: latest/edge
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log


### PR DESCRIPTION
# Description

Add the necessary github workflows to publish Gocert k8s to charmhub.

The charm name was registered in Charmhub and a token was generated and stored in GitHub secrets.

I also created this ticket to move the ownership to the team:
- https://discourse.charmhub.io/t/move-gocert-k8s-charm-ownership-to-canonical-telco/15215

The ownership has now been moved to the team.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
