### PR TITLE
feat: expose k8s service port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -58,7 +58,7 @@ class GocertCharm(ops.CharmBase):
         super().__init__(framework)
 
         self.port = 2111
-
+        self.unit.set_ports(self.port)
         self.container = self.unit.get_container("gocert")
         self.tls = TLSCertificatesProvidesV4(self, relationship_name="certificates")
         self.logs = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)


### PR DESCRIPTION
# Description

Expose k8s service port to make GoCert accessible outside of the k8s cluster.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
