### PR TITLE
fix: upload charm for multi arch

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-charm-${{ matrix.arch.arch }}
-      
+
       - name: Get Charm Under Test Path
         id: charm-path
         run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
@@ -39,7 +39,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: latest/edge
-  
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   publish-charm:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,11 +26,15 @@ jobs:
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
-
+          name: built-charm-${{ matrix.arch.arch }}
+      
       - name: Get Charm Under Test Path
         id: charm-path
         run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
+      - name: Select Charmhub channel
+        uses: canonical/charming-actions/channel@2.6.2
+        id: channel
 
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
@@ -31,8 +42,8 @@ jobs:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: latest/edge
-
+          channel: "${{ steps.channel.outputs.name }}"
+  
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -32,17 +32,13 @@ jobs:
         id: charm-path
         run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
-      - name: Select Charmhub channel
-        uses: canonical/charming-actions/channel@2.6.2
-        id: channel
-
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+          channel: latest/edge
   
       - name: Archive charmcraft logs
         if: failure()


### PR DESCRIPTION
# Description

PR #20 introduced an issue where we would not fetch the correct charm file to publish. Since we build using multi-arch, we also want to publish using multi-arch.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
